### PR TITLE
docs(plan): draft character count product spec

### DIFF
--- a/feature/character-count-display/product-spec.md
+++ b/feature/character-count-display/product-spec.md
@@ -1,0 +1,113 @@
+# Product Spec — Character Count Display
+
+**AIDLC phase:** Plan  
+**Audience:** Product, engineering leads, stakeholders — **product language only** (no implementation or stack). Unresolved product questions should be **asked in chat** first; this file records **decisions** after they are made.
+
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Feature** | Character count display for note text entry |
+| **Status** | Draft - awaiting product clarification and approval |
+| **Author** | Cursor Cloud Agent |
+| **Created** | 2026-04-29 |
+| **Last updated** | 2026-04-29 |
+| **Related Tech Spec** | `feature/character-count-display/tech-spec.md` (to be created in `/design`) |
+
+## Problem & audience
+
+### Problem statement
+
+People writing or updating notes currently have no immediate feedback on how much text they have entered in the note body field. This makes it harder to judge note length while writing and removes a simple piece of interface feedback that users often expect in a text-entry experience.
+
+### Who it's for
+
+- People creating a new note
+- People editing an existing note
+
+### Current experience (baseline)
+
+When a user types into the note text field, the page shows only the text they enter. There is no count displayed beneath the editor, and there is no live feedback that reflects the current character total as the content changes.
+
+## Outcomes & business impact
+
+### Desired outcomes
+
+- Give users immediate feedback about the current length of the note text they are entering
+- Make the note-writing experience feel more informative and responsive without changing the existing flow for adding or editing notes
+- Add clear acceptance evidence for this behavior so the product can be validated reliably
+
+### Success criteria (for Validate)
+
+These tie directly to the **scorecard** in `/ship`. Each should be **testable** or **evidence-based** without reading code.
+
+| # | Criterion | How we'll verify |
+|---|-----------|------------------|
+| 1 | A character count is shown below the note text editor on note-entry screens | Manual product check on note entry confirms the count is visibly present below the editor |
+| 2 | The count updates immediately as the user types, deletes, pastes, or otherwise changes note text | Manual interaction check shows the number changes in step with the visible note text |
+| 3 | The count uses simple wording in the format "`N` characters" | Product check confirms the displayed copy matches the agreed format |
+| 4 | Automated end-to-end coverage verifies the count is displayed and updates live | Validate evidence includes a passing Playwright scenario for this behavior |
+
+### Business impact
+
+This is a small usability improvement rather than a revenue feature. Its value is improved writing feedback for users and stronger confidence in the quality of the note editor through automated validation.
+
+## User experience & scenarios
+
+### Key scenarios
+
+Describe **critical paths** from the user's perspective (not API calls).
+
+1. **Create a note with live length feedback** — A user opens the note creation flow, types into the note text field, and sees a character count below the editor update in real time to reflect the current note text length.
+2. **Edit a note with live length feedback** — A user opens an existing note for editing, sees the current note text represented by a character count, and sees that count update in real time as the text changes.
+
+### Experience principles
+
+- The count should be easy to notice without distracting from writing
+- The wording should be plain and unambiguous
+- The feedback should feel immediate to the user as they type
+- The feature should not interfere with the existing add/edit note workflow
+
+## Scope
+
+### In scope
+
+- Showing a character count beneath the note text editor during note entry
+- Updating the displayed count as note text changes
+- Using the "`N` characters" format described in the issue
+- Capturing this behavior in end-to-end validation
+
+### Out of scope
+
+- Adding a character count for the note title field
+- Introducing character limits, warnings, or validation rules based on note length
+- Changing the saved content of notes
+- Adding a character count to read-only note viewing screens
+
+### Dependencies on other teams or features
+
+- No external team dependency is required for this feature
+- The feature should align with the existing issue tracker item: GitHub issue #3
+
+## Constraints (non-technical where possible)
+
+- The count must be presented below the note text editor, consistent with the issue request
+- The display format must remain simple and readable as "`N` characters"
+- The feature should preserve the current note entry experience rather than redefine it
+
+## Decisions (optional)
+
+Short log of **resolved** product questions from conversation (not a substitute for asking in chat).
+
+| Date | Decision |
+|------|----------|
+| 2026-04-29 | The character count uses the format "`N` characters". |
+| 2026-04-29 | End-to-end validation must cover this behavior. |
+
+## Related documents
+
+- Tech Spec: `feature/character-count-display/tech-spec.md` (not yet created; `/design` owns this)
+- Issues: `#3` — Add character count display to note editor
+- ADRs (for awareness only — do not restate architecture here): None

--- a/feature/character-count-display/product-spec.md
+++ b/feature/character-count-display/product-spec.md
@@ -10,7 +10,7 @@
 | Field | Value |
 |-------|-------|
 | **Feature** | Character count display for note text entry |
-| **Status** | Draft - awaiting remaining product clarification and approval |
+| **Status** | Awaiting approval |
 | **Author** | Cursor Cloud Agent |
 | **Created** | 2026-04-29 |
 | **Last updated** | 2026-04-29 |
@@ -45,7 +45,7 @@ These tie directly to the **scorecard** in `/ship`. Each should be **testable** 
 
 | # | Criterion | How we'll verify |
 |---|-----------|------------------|
-| 1 | A character count is shown below the note text editor on note-entry screens | Manual product check on note entry confirms the count is visibly present below the editor |
+| 1 | A character count is shown below the note text editor on note-entry screens, including immediately for existing note text when an edit form finishes loading | Manual product check on add/edit note entry confirms the count is visibly present below the editor and reflects the current text shown in the form |
 | 2 | The count updates immediately as the user types, deletes, pastes, or otherwise changes note text, including spaces and line breaks | Manual interaction check shows the number changes in step with the visible note text exactly as entered |
 | 3 | The count uses simple wording in the format "`N` characters" | Product check confirms the displayed copy matches the agreed format |
 | 4 | Automated end-to-end coverage verifies the count is displayed and updates live | Validate evidence includes a passing Playwright scenario for this behavior |
@@ -61,7 +61,7 @@ This is a small usability improvement rather than a revenue feature. Its value i
 Describe **critical paths** from the user's perspective (not API calls).
 
 1. **Create a note with live length feedback** — A user opens the note creation flow, types into the note text field, and sees a character count below the editor update in real time to reflect the current note text length.
-2. **Edit a note with live length feedback** — A user opens an existing note for editing, sees the current note text represented by a character count, and sees that count update in real time as the text changes.
+2. **Edit a note with live length feedback** — A user opens an existing note for editing, immediately sees a character count that reflects the current note text once the form loads, and sees that count update in real time as the text changes.
 
 ### Experience principles
 
@@ -70,6 +70,7 @@ Describe **critical paths** from the user's perspective (not API calls).
 - The feedback should feel immediate to the user as they type
 - The feature should not interfere with the existing add/edit note workflow
 - The displayed count should reflect the note text exactly as entered, including spaces, pasted text, and line breaks
+- When editing an existing note, the count should appear immediately once the current note text is loaded into the form
 
 ## Scope
 
@@ -80,6 +81,7 @@ Describe **critical paths** from the user's perspective (not API calls).
 - Using the "`N` characters" format described in the issue
 - Capturing this behavior in end-to-end validation
 - Counting the note text exactly as entered, including spaces, pasted text, and line breaks
+- Showing the current count immediately when an existing note is opened for editing
 
 ### Out of scope
 
@@ -108,6 +110,7 @@ Short log of **resolved** product questions from conversation (not a substitute 
 |------|----------|
 | 2026-04-29 | The character count uses the format "`N` characters". |
 | 2026-04-29 | The count includes spaces, line breaks, and pasted text exactly as entered in the note text field. |
+| 2026-04-29 | On the edit screen, the existing note text should show its character count immediately once the form loads. |
 | 2026-04-29 | End-to-end validation must cover this behavior. |
 
 ## Related documents

--- a/feature/character-count-display/product-spec.md
+++ b/feature/character-count-display/product-spec.md
@@ -10,7 +10,7 @@
 | Field | Value |
 |-------|-------|
 | **Feature** | Character count display for note text entry |
-| **Status** | Awaiting approval |
+| **Status** | Approved |
 | **Author** | Cursor Cloud Agent |
 | **Created** | 2026-04-29 |
 | **Last updated** | 2026-04-29 |

--- a/feature/character-count-display/product-spec.md
+++ b/feature/character-count-display/product-spec.md
@@ -10,7 +10,7 @@
 | Field | Value |
 |-------|-------|
 | **Feature** | Character count display for note text entry |
-| **Status** | Draft - awaiting product clarification and approval |
+| **Status** | Draft - awaiting remaining product clarification and approval |
 | **Author** | Cursor Cloud Agent |
 | **Created** | 2026-04-29 |
 | **Last updated** | 2026-04-29 |
@@ -46,7 +46,7 @@ These tie directly to the **scorecard** in `/ship`. Each should be **testable** 
 | # | Criterion | How we'll verify |
 |---|-----------|------------------|
 | 1 | A character count is shown below the note text editor on note-entry screens | Manual product check on note entry confirms the count is visibly present below the editor |
-| 2 | The count updates immediately as the user types, deletes, pastes, or otherwise changes note text | Manual interaction check shows the number changes in step with the visible note text |
+| 2 | The count updates immediately as the user types, deletes, pastes, or otherwise changes note text, including spaces and line breaks | Manual interaction check shows the number changes in step with the visible note text exactly as entered |
 | 3 | The count uses simple wording in the format "`N` characters" | Product check confirms the displayed copy matches the agreed format |
 | 4 | Automated end-to-end coverage verifies the count is displayed and updates live | Validate evidence includes a passing Playwright scenario for this behavior |
 
@@ -69,6 +69,7 @@ Describe **critical paths** from the user's perspective (not API calls).
 - The wording should be plain and unambiguous
 - The feedback should feel immediate to the user as they type
 - The feature should not interfere with the existing add/edit note workflow
+- The displayed count should reflect the note text exactly as entered, including spaces, pasted text, and line breaks
 
 ## Scope
 
@@ -78,6 +79,7 @@ Describe **critical paths** from the user's perspective (not API calls).
 - Updating the displayed count as note text changes
 - Using the "`N` characters" format described in the issue
 - Capturing this behavior in end-to-end validation
+- Counting the note text exactly as entered, including spaces, pasted text, and line breaks
 
 ### Out of scope
 
@@ -96,6 +98,7 @@ Describe **critical paths** from the user's perspective (not API calls).
 - The count must be presented below the note text editor, consistent with the issue request
 - The display format must remain simple and readable as "`N` characters"
 - The feature should preserve the current note entry experience rather than redefine it
+- The character total must reflect the note text exactly as entered by the user, including spaces, line breaks, and pasted text
 
 ## Decisions (optional)
 
@@ -104,6 +107,7 @@ Short log of **resolved** product questions from conversation (not a substitute 
 | Date | Decision |
 |------|----------|
 | 2026-04-29 | The character count uses the format "`N` characters". |
+| 2026-04-29 | The count includes spaces, line breaks, and pasted text exactly as entered in the note text field. |
 | 2026-04-29 | End-to-end validation must cover this behavior. |
 
 ## Related documents

--- a/feature/character-count-display/tech-spec.md
+++ b/feature/character-count-display/tech-spec.md
@@ -12,7 +12,7 @@
 | **Unit / scope** | Add a live character count to the note text field on the add and edit note routes without changing persistence or routing behavior |
 | **Feature** | `feature/character-count-display/` · GitHub issue `#3` |
 | **Product Spec** | `feature/character-count-display/product-spec.md` |
-| **Status** | Draft - awaiting technical approval |
+| **Status** | Approved for build |
 | **Author** | Cursor Cloud Agent |
 | **Created** | 2026-04-29 |
 | **Last updated** | 2026-04-29 |
@@ -212,3 +212,4 @@ Testing reliability notes:
 | Date | Author | Changes |
 |------|--------|---------|
 | 2026-04-29 | Cursor Cloud Agent | Initial draft from approved Product Spec and design review passes |
+| 2026-04-29 | Cursor Cloud Agent | Marked Tech Spec approved after human design sign-off |

--- a/feature/character-count-display/tech-spec.md
+++ b/feature/character-count-display/tech-spec.md
@@ -1,0 +1,214 @@
+# Tech Spec — Character Count Display
+
+**AIDLC phase:** Design (one **Unit** per Tech Spec; split only if independently implementable)  
+**Grounding:** This document implements the approved **Product Spec** and must **link** to existing **ADRs** instead of re-deriving org-wide architecture.
+
+---
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Unit / scope** | Add a live character count to the note text field on the add and edit note routes without changing persistence or routing behavior |
+| **Feature** | `feature/character-count-display/` · GitHub issue `#3` |
+| **Product Spec** | `feature/character-count-display/product-spec.md` |
+| **Status** | Draft - awaiting technical approval |
+| **Author** | Cursor Cloud Agent |
+| **Created** | 2026-04-29 |
+| **Last updated** | 2026-04-29 |
+
+## Context
+
+### Summary
+
+This unit adds a character count below the existing note text textarea on both note-entry routes: `AddNote` and `EditNote`. The count is derived from the textarea's controlled value so it reflects spaces, line breaks, pasted text, and edits exactly as entered. The feature remains frontend-only: no API, routing, or database schema changes are required.
+
+### Existing system & documentation
+
+- **Repo layout / services:** React SPA routes and components live in `src/`, json-server data lives in `server/db.json`, and Playwright tests with page objects live in `tests/`.
+- **Relevant ADRs:** None in repo.
+- **Prior art in repo:**
+  - `src/components/AddNote.js` and `src/components/EditNote.js` already use local React state for `title` and `description`.
+  - `src/components/EditNote.js` hydrates existing note text asynchronously with `axios.get(...)`.
+  - `tests/pages/AddNotePage.ts` and `tests/pages/EditNotePage.ts` already model the note editor controls through stable ids such as `#notetext`.
+
+### Out of scope for this Unit
+
+- Character counts for the title field
+- Character limits, warnings, or validation rules
+- Any change to saved note payloads or JSON schema
+- Read-only note view changes
+- Analytics, feature flags, or deployment/environment changes
+
+## Architecture
+
+### High-level design
+
+The implementation stays within the existing route-based form architecture.
+
+1. `AddNote` remains the route container for create-note submission.
+2. `EditNote` remains the route container for fetching and updating an existing note.
+3. A shared presentational component should own the note-entry field rendering so the note text field, count placement, and accessibility wiring stay consistent across add and edit flows.
+4. Character count is derived from the current `description` string rather than stored in component state or persisted to the backend.
+5. The add route shows `0 characters` on initial render.
+6. The edit route should avoid a misleading transient `0 characters` before note data loads; instead, the count becomes visible as soon as the existing note text has been loaded into form state.
+
+Recommended component split:
+
+- **Route containers**
+  - `src/components/AddNote.js`
+  - `src/components/EditNote.js`
+- **Shared presentational child**
+  - Proposed: `src/components/NoteEditorFields.js`
+  - Responsibilities:
+    - render title and note text controls
+    - render character count beneath the note text textarea
+    - wire label-to-control associations
+    - expose a stable selector for the count element
+- **Optional helper**
+  - Proposed: `src/utils/formatCharacterCount.js`
+  - Responsibility: return the exact display string, e.g. `0 characters`, `3 characters`
+
+Example data flow:
+
+```text
+AddNote/EditNote state -> description value -> formatCharacterCount(description)
+                                       -> shared field component renders count
+```
+
+Edit route load sequence:
+
+```text
+mount EditNote
+-> fetch existing note
+-> set title + description
+-> mark editor data ready
+-> render count for loaded description
+-> continue live updates from onChange
+```
+
+### Integration points
+
+| System | Contract | Notes |
+|--------|----------|-------|
+| React Router | `/add` and `edit/:id` continue to mount `AddNote` and `EditNote` | No route changes |
+| json-server API | `POST /notes`, `GET /notes/:id`, `PUT /notes/:id` remain unchanged | Character count is not persisted |
+| Playwright page objects | Existing ids `#notetitle`, `#notetext`, `#submit`, `#submitEdit` stay stable | Add one stable locator for the count element |
+| GitHub Actions Playwright workflow | Existing `playwright.yml` and `playwright.config.ts` runtime remains valid | No CI config changes required for this feature alone |
+
+## Data
+
+- No schema or seed-data changes are required.
+- The persisted note shape remains `{ id, title, description }`.
+- Character count is a derived UI value only.
+- Counting rule: use the current textarea value exactly as represented in React state, including spaces, pasted text, and line breaks.
+- The implementation must not add a stored `characterCount` field because the current edit flow performs a full `PUT` with only `title` and `description`.
+
+## APIs & contracts
+
+- **External API changes:** None.
+- **Network behavior:** Existing axios requests remain unchanged.
+- **UI contract:**
+  - `#notetext` remains the textarea selector used by tests and page objects.
+  - A new dedicated count element should be rendered directly below the textarea.
+  - Proposed stable selector: `id="notetext-character-count"`.
+  - Display format must be exactly `N characters`.
+  - On Add Note, the counter is visible immediately with `0 characters`.
+  - On Edit Note, the counter becomes visible immediately after the existing note text is loaded into the form and reflects that loaded text before any user edits.
+
+## UI / client
+
+- Keep note entry state local to the route components; no context or global store is needed.
+- Derive the count from `description.length`; do not maintain a separate `characterCount` state.
+- Preserve the current submit button behavior and navigation flow.
+- Improve form semantics while touching the markup:
+  - bind labels with `htmlFor`
+  - use `aria-describedby` on the textarea to associate the helper text/count
+- Treat the count as helper text, not validation text.
+- Avoid `aria-live` by default so screen readers are not forced to announce the count on every keystroke.
+- Preserve the existing field ids to minimize test churn.
+
+Recommended UI behavior by route:
+
+| Route | Initial state | After user input |
+|------|---------------|------------------|
+| Add Note | Show `0 characters` below an empty textarea | Update count on each textarea change |
+| Edit Note | Hide count until existing note text is loaded, then show the loaded count immediately | Update count on each textarea change |
+
+## Security & privacy
+
+- No auth, permission, or secret-handling changes are involved.
+- No new user data is collected or persisted.
+- Risk is limited to frontend regressions in note entry behavior.
+
+## Acceptance criteria (for Review)
+
+Testable conditions that **Review** will check against implementation.
+
+- [ ] Add Note shows a character count directly below the note text textarea on first render.
+- [ ] Add Note displays `0 characters` before any note text is entered.
+- [ ] Edit Note shows the current count as soon as existing note text has loaded into the form, without persisting or submitting an extra field.
+- [ ] The count reflects the textarea value exactly as entered, including spaces, pasted text, and line breaks.
+- [ ] The displayed copy is always formatted as `N characters`.
+- [ ] Existing add/edit submit behavior and note persistence remain unchanged.
+- [ ] A stable selector exists for the count element and is used by tests/page objects.
+- [ ] Accessibility of the touched form markup is improved through proper label association and helper-text wiring.
+
+## Testing approach
+
+| Layer | What we prove | Notes |
+|-------|----------------|-------|
+| Unit | Exact count formatting logic returns the expected `N characters` string for empty text, plain text, spaces, and line breaks | Best implemented via a small helper function if extracted |
+| Integration | Add/edit form rendering shows the counter in the correct location and updates from controlled textarea state; edit flow waits for async data load before asserting initial count | Use focused React component tests with mocked data loading where practical |
+| E2E / manual | Add flow and edit flow both surface the counter and update it live in the browser; no submit/navigation regressions | Extend Playwright page objects with a count locator and explicit count assertions |
+
+Suggested Build+Test coverage:
+
+- Add a small focused unit test if a formatter helper is introduced.
+- Add targeted component/integration coverage for:
+  - Add Note initial empty state
+  - Add Note live updates on textarea changes
+  - Edit Note loaded-state initial count
+  - Edit Note live updates after the async fetch
+- Extend Playwright with two focused scenarios:
+  - count behavior on Add Note
+  - count behavior on Edit Note
+
+Testing reliability notes:
+
+- Avoid fixed sleeps for count assertions; prefer condition-based assertions.
+- New Playwright tests should create their own note data and avoid assumptions about global list order because local Playwright runs are parallelized against a shared JSON DB.
+- Edit-page assertions must wait for loaded textarea content or count text before asserting the initial edit-state value.
+
+## Rollout & operations
+
+### Rollout plan
+
+- No phased rollout or feature flag is required.
+- Ship as a normal frontend change with updated automated tests.
+
+### Monitoring & observability
+
+- No production-specific monitoring changes are required for this UI-only feature.
+- Confidence comes from component/integration coverage, Playwright coverage, and manual validation of the add/edit flows.
+
+### Rollback
+
+- Revert the shared field/count UI changes and accompanying tests.
+- Because there is no schema or API change, rollback is frontend-only and low risk.
+
+## Risks & open technical questions
+
+| Risk / question | Mitigation or owner |
+|-----------------|---------------------|
+| Edit route can render before existing note text loads, causing a misleading transient `0 characters` if implemented naively | Design decision in this spec: hide the count until edit data hydration completes, then show the loaded count immediately |
+| Add and edit forms are near-duplicates, which can cause selector or copy drift | Use a shared presentational component for the note-entry fields |
+| Playwright local runs mutate a shared `server/db.json` while running in parallel | Keep new E2E cases isolated and assert only on note data each test creates |
+| Current form labels are not programmatically associated with controls | Improve label wiring as part of this feature since the touched markup already contains the relevant fields |
+| Should the count selector follow existing id conventions or introduce a `data-testid`? | Proposed in this spec: use `id="notetext-character-count"` to match current page-object conventions |
+
+## Change history
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-04-29 | Cursor Cloud Agent | Initial draft from approved Product Spec and design review passes |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add the approved AIDLC plan artifact at `feature/character-count-display/product-spec.md`
- add the approved AIDLC design artifact at `feature/character-count-display/tech-spec.md`
- capture the agreed technical design for a live note-text character count on add/edit flows

## Approved design decisions
- keep Add/Edit as route-level containers and extract shared note-entry field rendering
- derive the character count from the controlled note-text value rather than persisting it
- show `0 characters` immediately on Add Note
- hide the counter on Edit Note until existing note text loads, then show the loaded count immediately
- preserve existing field/button ids and add a stable count selector `#notetext-character-count`
- improve touched form accessibility with proper label wiring and `aria-describedby`

## Phase status
- Product Spec is `Approved`
- Tech Spec is `Approved for build`
- This run stopped before `/build`

## Validation
- design review passes completed for architecture, frontend, backend, testing strategy, and CI/runtime
- existing Playwright suite had previously passed on this branch (`npm test`) ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cab643b-bb60-468f-81d3-ae9b68307da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cab643b-bb60-468f-81d3-ae9b68307da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

