### PR TITLE
feat: add note card created and last-edited timestamps

### DIFF
--- a/server/db.json
+++ b/server/db.json
@@ -3,7 +3,8 @@
     {
       "title": "Test note",
       "description": "This is just a test note that has some jibberish in it just for testing.\n",
-      "id": "1"
+      "id": "1",
+      "createdAt": "2026-04-01T12:00:00.000Z"
     }
   ]
 }

--- a/src/components/AddNote.js
+++ b/src/components/AddNote.js
@@ -11,7 +11,11 @@ const AddNote = () => {
   const handleSubmit = async (event) => {
     event.preventDefault();
     try {
-      await axios.post('http://localhost:3004/notes', { title, description });
+      await axios.post('http://localhost:3004/notes', {
+        title,
+        description,
+        createdAt: new Date().toISOString(),
+      });
       navigate('/');
     } catch (error) {
       console.error('Error adding note: ', error);

--- a/src/components/EditNote.js
+++ b/src/components/EditNote.js
@@ -28,7 +28,11 @@ const EditNote = () => {
   const handleSubmit = async (event) => {
     event.preventDefault();
     try {
-      await axios.put('http://localhost:3004/notes/' + id, { title, description });
+      await axios.patch('http://localhost:3004/notes/' + id, {
+        title,
+        description,
+        updatedAt: new Date().toISOString(),
+      });
       navigate('/');
     } catch (error) {
       console.error('Error editing note: ', error);

--- a/src/components/ListNotes.js
+++ b/src/components/ListNotes.js
@@ -31,34 +31,36 @@ const ListNotes = () => {
 	return (
 		<div><h2>List of Notes</h2>
 			<table id={"notes"}>
-				{notes.map((post) => {
-					const timestampDetails = getNoteTimestampDetails(post);
+				<tbody>
+					{notes.map((post) => {
+						const timestampDetails = getNoteTimestampDetails(post);
 
-					return (
-						<tr key={post.id}>
-							<td id={"notetitle_"+post.id}>
-								<div>{post.title}</div>
-								{timestampDetails ? (
-									<time
-										id={"notetimestamp_" + post.id}
-										dateTime={timestampDetails.isoString}
-									>
-										{timestampDetails.text}
-									</time>
-								) : null}
-							</td>
-							<td>
-								<Link className={'btn btn-success'} id={'view_'+post.id} to={`/view/${post.id}`}>View</Link>
-							</td>
-							<td>
-								<Link className={'btn btn-warning'} id={'edit_'+post.id} to={`/edit/${post.id}`}>Edit</Link>
-							</td>
-							<td>
-								<Link className={'btn btn-danger'}id={'delete_'+post.id} onClick={() => onDelete(post.id)} >Delete</Link>
-							</td>
-						</tr>
-					);
-				})}
+						return (
+							<tr key={post.id}>
+								<td id={"notetitle_"+post.id}>
+									<div>{post.title}</div>
+									{timestampDetails ? (
+										<time
+											id={"notetimestamp_" + post.id}
+											dateTime={timestampDetails.isoString}
+										>
+											{timestampDetails.text}
+										</time>
+									) : null}
+								</td>
+								<td>
+									<Link className={'btn btn-success'} id={'view_'+post.id} to={`/view/${post.id}`}>View</Link>
+								</td>
+								<td>
+									<Link className={'btn btn-warning'} id={'edit_'+post.id} to={`/edit/${post.id}`}>Edit</Link>
+								</td>
+								<td>
+									<Link className={'btn btn-danger'}id={'delete_'+post.id} onClick={() => onDelete(post.id)} >Delete</Link>
+								</td>
+							</tr>
+						);
+					})}
+				</tbody>
 			</table>
 		</div>
 	)

--- a/src/components/ListNotes.js
+++ b/src/components/ListNotes.js
@@ -1,6 +1,7 @@
 import {useEffect, useState} from "react";
 import axios from 'axios';
 import {Link} from "react-router-dom";
+import { getNoteTimestampDetails } from '../utils/formatNoteTimestamp';
 
 const ListNotes = () => {
 	const [notes, setNotes] = useState([]);
@@ -30,22 +31,34 @@ const ListNotes = () => {
 	return (
 		<div><h2>List of Notes</h2>
 			<table id={"notes"}>
-				{notes.map((post) => (
-					<tr key={post.id}>
-						<td id={"notetitle_"+post.id}>
-							{post.title}
-						</td>
-						<td>
-							<Link className={'btn btn-success'} id={'view_'+post.id} to={`/view/${post.id}`}>View</Link>
-						</td>
-						<td>
-							<Link className={'btn btn-warning'} id={'edit_'+post.id} to={`/edit/${post.id}`}>Edit</Link>
-						</td>
-						<td>
-							<Link className={'btn btn-danger'}id={'delete_'+post.id} onClick={() => onDelete(post.id)} >Delete</Link>
-						</td>
-					</tr>
-				))}
+				{notes.map((post) => {
+					const timestampDetails = getNoteTimestampDetails(post);
+
+					return (
+						<tr key={post.id}>
+							<td id={"notetitle_"+post.id}>
+								<div>{post.title}</div>
+								{timestampDetails ? (
+									<time
+										id={"notetimestamp_" + post.id}
+										dateTime={timestampDetails.isoString}
+									>
+										{timestampDetails.text}
+									</time>
+								) : null}
+							</td>
+							<td>
+								<Link className={'btn btn-success'} id={'view_'+post.id} to={`/view/${post.id}`}>View</Link>
+							</td>
+							<td>
+								<Link className={'btn btn-warning'} id={'edit_'+post.id} to={`/edit/${post.id}`}>Edit</Link>
+							</td>
+							<td>
+								<Link className={'btn btn-danger'}id={'delete_'+post.id} onClick={() => onDelete(post.id)} >Delete</Link>
+							</td>
+						</tr>
+					);
+				})}
 			</table>
 		</div>
 	)

--- a/src/components/NoteTimestamp.integration.test.js
+++ b/src/components/NoteTimestamp.integration.test.js
@@ -1,20 +1,47 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import axios from 'axios';
+const mockNavigate = jest.fn();
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+  },
+}));
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    Link: ({ children, to, ...props }) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ id: '1' }),
+  }),
+  { virtual: true }
+);
+
 import AddNote from './AddNote';
 import EditNote from './EditNote';
 import ListNotes from './ListNotes';
 
-jest.mock('axios');
+const mockedAxios = axios;
 
 describe('note timestamp integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test('list shows created timestamp for seeded notes', async () => {
-    axios.get.mockResolvedValueOnce({
+    mockedAxios.get.mockResolvedValueOnce({
       data: [
         {
           id: '1',
@@ -25,11 +52,7 @@ describe('note timestamp integration', () => {
       ],
     });
 
-    render(
-      <MemoryRouter>
-        <ListNotes />
-      </MemoryRouter>
-    );
+    render(<ListNotes />);
 
     expect(await screen.findByText('Seeded note')).toBeInTheDocument();
 
@@ -39,54 +62,58 @@ describe('note timestamp integration', () => {
     expect(timestamp).toHaveAttribute('datetime', '2026-04-01T12:00:00.000Z');
   });
 
-  test('add note posts createdAt and returns to list with created label', async () => {
-    jest.useFakeTimers().setSystemTime(new Date('2026-04-29T14:00:00.000Z'));
-
-    axios.post.mockResolvedValueOnce({});
-    axios.get.mockResolvedValueOnce({
+  test('list shows last edited timestamp when updatedAt is present', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
       data: [
         {
-          id: '7',
-          title: 'New note',
-          description: 'Fresh text',
-          createdAt: '2026-04-29T14:00:00.000Z',
+          id: '1',
+          title: 'Edited note',
+          description: 'Existing note',
+          createdAt: '2026-04-01T12:00:00.000Z',
+          updatedAt: '2026-04-29T15:30:00.000Z',
         },
       ],
     });
 
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<ListNotes />);
 
-    render(
-      <MemoryRouter initialEntries={['/add']}>
-        <Routes>
-          <Route path="/add" element={<AddNote />} />
-          <Route path="/" element={<ListNotes />} />
-        </Routes>
-      </MemoryRouter>
-    );
+    expect(await screen.findByText('Edited note')).toBeInTheDocument();
 
-    await user.type(screen.getByLabelText('Title:'), 'New note');
-    await user.type(screen.getByLabelText('Note Text:'), 'Fresh text');
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    const timestamp = screen.getByText(/Last edited:/);
+    expect(timestamp).toHaveAttribute('id', 'notetimestamp_1');
+    expect(timestamp).toHaveAttribute('datetime', '2026-04-29T15:30:00.000Z');
+  });
+
+  test('add note posts createdAt and navigates back to the list', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-29T14:00:00.000Z'));
+
+    mockedAxios.post.mockResolvedValueOnce({});
+
+    render(<AddNote />);
+
+    fireEvent.change(screen.getByLabelText('Title:'), {
+      target: { value: 'New note' },
+    });
+    fireEvent.change(screen.getByLabelText('Note Text:'), {
+      target: { value: 'Fresh text' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() =>
-      expect(axios.post).toHaveBeenCalledWith('http://localhost:3004/notes', {
+      expect(mockedAxios.post).toHaveBeenCalledWith('http://localhost:3004/notes', {
         title: 'New note',
         description: 'Fresh text',
         createdAt: '2026-04-29T14:00:00.000Z',
       })
     );
 
-    expect(await screen.findByText('New note')).toBeInTheDocument();
-    expect(screen.getByText(/Created:/)).toBeInTheDocument();
-
-    jest.useRealTimers();
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
-  test('edit note patches updatedAt and list switches to last edited label', async () => {
+  test('edit note patches updatedAt and navigates back to the list', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2026-04-29T15:30:00.000Z'));
 
-    axios.get.mockResolvedValueOnce({
+    mockedAxios.get.mockResolvedValueOnce({
       data: {
         id: '1',
         title: 'Seeded note',
@@ -94,50 +121,27 @@ describe('note timestamp integration', () => {
         createdAt: '2026-04-01T12:00:00.000Z',
       },
     });
-    axios.patch.mockResolvedValueOnce({});
-    axios.get.mockResolvedValueOnce({
-      data: [
-        {
-          id: '1',
-          title: 'Seeded note',
-          description: 'Updated note text',
-          createdAt: '2026-04-01T12:00:00.000Z',
-          updatedAt: '2026-04-29T15:30:00.000Z',
-        },
-      ],
-    });
+    mockedAxios.patch.mockResolvedValueOnce({});
 
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <MemoryRouter initialEntries={['/edit/1']}>
-        <Routes>
-          <Route path="/edit/:id" element={<EditNote />} />
-          <Route path="/" element={<ListNotes />} />
-        </Routes>
-      </MemoryRouter>
-    );
+    render(<EditNote />);
 
     expect(await screen.findByDisplayValue('Seeded note')).toBeInTheDocument();
 
     const noteText = screen.getByLabelText('Note Text:');
-    await user.clear(noteText);
-    await user.type(noteText, 'Updated note text');
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    fireEvent.change(noteText, { target: { value: 'Updated note text' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() =>
-      expect(axios.patch).toHaveBeenCalledWith('http://localhost:3004/notes/1', {
-        title: 'Seeded note',
-        description: 'Updated note text',
-        updatedAt: '2026-04-29T15:30:00.000Z',
-      })
+      expect(mockedAxios.patch).toHaveBeenCalledWith(
+        'http://localhost:3004/notes/1',
+        expect.objectContaining({
+          title: 'Seeded note',
+          description: 'Updated note text',
+          updatedAt: expect.stringMatching(/^2026-04-29T15:30:00\.\d{3}Z$/),
+        })
+      )
     );
 
-    expect(await screen.findByText('Seeded note')).toBeInTheDocument();
-    const timestamp = screen.getByText(/Last edited:/);
-    expect(timestamp).toBeInTheDocument();
-    expect(timestamp).toHaveAttribute('datetime', '2026-04-29T15:30:00.000Z');
-
-    jest.useRealTimers();
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 });

--- a/src/components/NoteTimestamp.integration.test.js
+++ b/src/components/NoteTimestamp.integration.test.js
@@ -1,0 +1,143 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import axios from 'axios';
+import AddNote from './AddNote';
+import EditNote from './EditNote';
+import ListNotes from './ListNotes';
+
+jest.mock('axios');
+
+describe('note timestamp integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('list shows created timestamp for seeded notes', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: '1',
+          title: 'Seeded note',
+          description: 'Existing note',
+          createdAt: '2026-04-01T12:00:00.000Z',
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <ListNotes />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Seeded note')).toBeInTheDocument();
+
+    const timestamp = screen.getByText(/Created:/);
+    expect(timestamp).toHaveAttribute('id', 'notetimestamp_1');
+    expect(timestamp.tagName).toBe('TIME');
+    expect(timestamp).toHaveAttribute('datetime', '2026-04-01T12:00:00.000Z');
+  });
+
+  test('add note posts createdAt and returns to list with created label', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-29T14:00:00.000Z'));
+
+    axios.post.mockResolvedValueOnce({});
+    axios.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: '7',
+          title: 'New note',
+          description: 'Fresh text',
+          createdAt: '2026-04-29T14:00:00.000Z',
+        },
+      ],
+    });
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <MemoryRouter initialEntries={['/add']}>
+        <Routes>
+          <Route path="/add" element={<AddNote />} />
+          <Route path="/" element={<ListNotes />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText('Title:'), 'New note');
+    await user.type(screen.getByLabelText('Note Text:'), 'Fresh text');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(axios.post).toHaveBeenCalledWith('http://localhost:3004/notes', {
+        title: 'New note',
+        description: 'Fresh text',
+        createdAt: '2026-04-29T14:00:00.000Z',
+      })
+    );
+
+    expect(await screen.findByText('New note')).toBeInTheDocument();
+    expect(screen.getByText(/Created:/)).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  test('edit note patches updatedAt and list switches to last edited label', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-29T15:30:00.000Z'));
+
+    axios.get.mockResolvedValueOnce({
+      data: {
+        id: '1',
+        title: 'Seeded note',
+        description: 'Existing note',
+        createdAt: '2026-04-01T12:00:00.000Z',
+      },
+    });
+    axios.patch.mockResolvedValueOnce({});
+    axios.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: '1',
+          title: 'Seeded note',
+          description: 'Updated note text',
+          createdAt: '2026-04-01T12:00:00.000Z',
+          updatedAt: '2026-04-29T15:30:00.000Z',
+        },
+      ],
+    });
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <MemoryRouter initialEntries={['/edit/1']}>
+        <Routes>
+          <Route path="/edit/:id" element={<EditNote />} />
+          <Route path="/" element={<ListNotes />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('Seeded note')).toBeInTheDocument();
+
+    const noteText = screen.getByLabelText('Note Text:');
+    await user.clear(noteText);
+    await user.type(noteText, 'Updated note text');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(axios.patch).toHaveBeenCalledWith('http://localhost:3004/notes/1', {
+        title: 'Seeded note',
+        description: 'Updated note text',
+        updatedAt: '2026-04-29T15:30:00.000Z',
+      })
+    );
+
+    expect(await screen.findByText('Seeded note')).toBeInTheDocument();
+    const timestamp = screen.getByText(/Last edited:/);
+    expect(timestamp).toBeInTheDocument();
+    expect(timestamp).toHaveAttribute('datetime', '2026-04-29T15:30:00.000Z');
+
+    jest.useRealTimers();
+  });
+});

--- a/src/utils/formatNoteTimestamp.js
+++ b/src/utils/formatNoteTimestamp.js
@@ -1,0 +1,42 @@
+const timestampFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+  timeZone: 'UTC',
+  timeZoneName: 'short',
+});
+
+export function formatNoteTimestamp(isoString) {
+  const date = new Date(isoString);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return timestampFormatter.format(date);
+}
+
+export function getNoteTimestampDetails(note) {
+  const isoString = note.updatedAt ?? note.createdAt;
+
+  if (!isoString) {
+    return null;
+  }
+
+  const displayText = formatNoteTimestamp(isoString);
+
+  if (!displayText) {
+    return null;
+  }
+
+  const label = note.updatedAt ? 'Last edited' : 'Created';
+
+  return {
+    label,
+    isoString,
+    displayText,
+    text: `${label}: ${displayText}`,
+  };
+}

--- a/src/utils/formatNoteTimestamp.test.js
+++ b/src/utils/formatNoteTimestamp.test.js
@@ -1,0 +1,49 @@
+import {
+  formatNoteTimestamp,
+  getNoteTimestampDetails,
+} from './formatNoteTimestamp';
+
+describe('formatNoteTimestamp', () => {
+  test('formats a valid ISO timestamp into readable absolute text', () => {
+    expect(formatNoteTimestamp('2026-04-01T12:00:00.000Z')).toBe(
+      'Apr 1, 2026, 12:00 PM UTC'
+    );
+  });
+
+  test('returns null for an invalid timestamp', () => {
+    expect(formatNoteTimestamp('not-a-date')).toBeNull();
+  });
+});
+
+describe('getNoteTimestampDetails', () => {
+  test('uses createdAt when a note has never been edited', () => {
+    expect(
+      getNoteTimestampDetails({
+        createdAt: '2026-04-01T12:00:00.000Z',
+      })
+    ).toEqual({
+      label: 'Created',
+      isoString: '2026-04-01T12:00:00.000Z',
+      displayText: 'Apr 1, 2026, 12:00 PM UTC',
+      text: 'Created: Apr 1, 2026, 12:00 PM UTC',
+    });
+  });
+
+  test('prefers updatedAt and last edited label when present', () => {
+    expect(
+      getNoteTimestampDetails({
+        createdAt: '2026-04-01T12:00:00.000Z',
+        updatedAt: '2026-04-29T14:00:00.000Z',
+      })
+    ).toEqual({
+      label: 'Last edited',
+      isoString: '2026-04-29T14:00:00.000Z',
+      displayText: 'Apr 29, 2026, 2:00 PM UTC',
+      text: 'Last edited: Apr 29, 2026, 2:00 PM UTC',
+    });
+  });
+
+  test('returns null when note has no usable timestamp metadata', () => {
+    expect(getNoteTimestampDetails({})).toBeNull();
+  });
+});

--- a/tests/NotesTests.spec.ts
+++ b/tests/NotesTests.spec.ts
@@ -20,7 +20,8 @@ test("verify adding a note", async ({ page }) => {
     const noteId = await addnotepage.addNote("AutomatedTest", "Some text here");
 
     await expect(page.locator("h2")).toHaveText("List of Notes");
-    await expect(page.locator(`#notetitle_${noteId}`)).toHaveText("AutomatedTest");
+    await expect(page.locator(`#notetitle_${noteId} > div`)).toHaveText("AutomatedTest");
+    await homepage.expectTimestampById(noteId, /^Created: .+/);
 });
 
 test("verify add note required fields", async ({ page }) => {
@@ -48,7 +49,7 @@ test("verify deleting a note", async ({ page }) => {
 
     const addnotepage = new AddNotePage(page);
     const noteId = await addnotepage.addNote("NoteToDelete", "Some text here");
-    await expect(page.locator(`#notetitle_${noteId}`)).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(`#notetitle_${noteId} > div`)).toBeVisible({ timeout: 3000 });
     await homepage.deleteNoteById(noteId);
     await expect(page.locator(`#notetitle_${noteId}`)).toHaveCount(0);
 });
@@ -59,8 +60,9 @@ test("verify editing a note", async ({ page }) => {
 
     const addnotepage = new AddNotePage(page);
     const noteId = await addnotepage.addNote("NoteToEdit", "Some text here");
-    await expect(page.locator(`#notetitle_${noteId}`)).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(`#notetitle_${noteId} > div`)).toBeVisible({ timeout: 3000 });
     await homepage.editNoteById(noteId, "NoteToEdit", "updated text for a test");
+    await homepage.expectTimestampById(noteId, /^Last edited: .+/);
 });
 
 test("verify edit note required fields", async ({ page }) => {
@@ -69,7 +71,7 @@ test("verify edit note required fields", async ({ page }) => {
 
     const addnotepage = new AddNotePage(page);
     const noteId = await addnotepage.addNote("EditNoteRequiredFields", "Some text here");
-    await expect(page.locator(`#notetitle_${noteId}`)).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(`#notetitle_${noteId} > div`)).toBeVisible({ timeout: 3000 });
 
     await homepage.goToEditNoteById(noteId);
     const editnotepage = new EditNotePage(page);
@@ -83,7 +85,7 @@ test("verify edit note character count", async ({ page }) => {
     const addnotepage = new AddNotePage(page);
     const initialText = "Seed text";
     const noteId = await addnotepage.addNote("EditCharacterCount", initialText);
-    await expect(page.locator(`#notetitle_${noteId}`)).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(`#notetitle_${noteId} > div`)).toBeVisible({ timeout: 3000 });
 
     await homepage.goToEditNoteById(noteId);
     const editnotepage = new EditNotePage(page);
@@ -91,4 +93,10 @@ test("verify edit note character count", async ({ page }) => {
     await editnotepage.expectCharacterCount("9 characters");
     await editnotepage.notetext.fill("Updated value");
     await editnotepage.expectCharacterCount("13 characters");
+});
+
+test("verify seeded note shows created timestamp", async ({ page }) => {
+    const homepage = new HomePage(page);
+    await expect(page.locator("#notetitle_1 > div")).toHaveText("Test note");
+    await homepage.expectTimestampById("1", /^Created: .+/);
 });

--- a/tests/NotesTests.spec.ts
+++ b/tests/NotesTests.spec.ts
@@ -4,6 +4,8 @@ import { AddNotePage } from "./pages/AddNotePage";
 import { reSeedData } from "./utils/Utils";
 import { EditNotePage } from "./pages/EditNotePage";
 
+test.describe.configure({ mode: "serial" });
+
 test.afterAll(async () => {
     await reSeedData();
 });
@@ -61,8 +63,13 @@ test("verify editing a note", async ({ page }) => {
     const addnotepage = new AddNotePage(page);
     const noteId = await addnotepage.addNote("NoteToEdit", "Some text here");
     await expect(page.locator(`#notetitle_${noteId} > div`)).toBeVisible({ timeout: 3000 });
-    await homepage.editNoteById(noteId, "NoteToEdit", "updated text for a test");
+    await homepage.goToEditNoteById(noteId);
+    const editnotepage = new EditNotePage(page);
+    await editnotepage.editNote("NoteToEdit", "updated text for a test");
+    await expect(page.locator("h2")).toHaveText("List of Notes");
     await homepage.expectTimestampById(noteId, /^Last edited: .+/);
+    await page.locator(`#view_${noteId}`).click();
+    await expect(page.locator("#noteDescription")).toHaveText("updated text for a test");
 });
 
 test("verify edit note required fields", async ({ page }) => {

--- a/tests/pages/HomePage.ts
+++ b/tests/pages/HomePage.ts
@@ -39,6 +39,18 @@ export class HomePage {
         await this.page.locator(`#delete_${noteId}`).click();
     }
 
+    getNoteTitle(noteId: string): Locator {
+        return this.page.locator(`#notetitle_${noteId} > div`);
+    }
+
+    getNoteTimestamp(noteId: string): Locator {
+        return this.page.locator(`#notetimestamp_${noteId}`);
+    }
+
+    async expectTimestampById(noteId: string, expectedText: RegExp | string): Promise<void> {
+        await expect(this.getNoteTimestamp(noteId)).toHaveText(expectedText);
+    }
+
     /**
      * Edits a note by id, then opens view for that id and checks the description body.
      * @param noteId - Server id; matches `edit_${noteId}` / `view_${noteId}` in the list.

--- a/tests/resources/seedData.json
+++ b/tests/resources/seedData.json
@@ -3,7 +3,8 @@
     {
       "title": "Test note",
       "description": "This is just a test note that has some jibberish in it just for testing.\n",
-      "id": "1"
+      "id": "1",
+      "createdAt": "2026-04-01T12:00:00.000Z"
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement Tech Spec sections **Architecture**, **Data**, and **UI / client** for issue #7 by persisting `createdAt` on create, recording `updatedAt` on edit, and rendering a shared timestamp helper on each list note card
- backfill `server/db.json` and `tests/resources/seedData.json` so seeded demo notes always render a visible timestamp
- implement Tech Spec **Testing approach** coverage with helper/component tests plus Playwright assertions for seeded, created, and edited note timestamp flows
- stabilize build verification by using valid table markup and serializing Playwright note-mutation tests against the shared JSON server fixture

## Verification completed
- `CI=1 npx react-scripts test --watch=false --runTestsByPath src/utils/formatCharacterCount.test.js src/components/NoteEditorFields.test.js src/utils/formatNoteTimestamp.test.js src/components/NoteTimestamp.integration.test.js`
- `npm run build`
- `npm test`

## Traceability
- Issue: #7
- Tech Spec: `feature/note-card-last-edited-timestamp/tech-spec.md`
- Sections implemented: Architecture, Data, APIs & contracts, UI / client, Testing approach
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad5c73c0-8bba-499c-93ae-ddb9cb621c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad5c73c0-8bba-499c-93ae-ddb9cb621c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

