### PR TITLE
fix: display note timestamps in viewer local time

### DIFF
--- a/src/components/NoteTimestamp.integration.test.js
+++ b/src/components/NoteTimestamp.integration.test.js
@@ -30,14 +30,17 @@ import EditNote from './EditNote';
 import ListNotes from './ListNotes';
 
 const mockedAxios = axios;
+const originalTimeZone = process.env.TZ;
 
 describe('note timestamp integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.TZ = 'America/New_York';
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    process.env.TZ = originalTimeZone;
   });
 
   test('list shows created timestamp for seeded notes', async () => {
@@ -60,6 +63,8 @@ describe('note timestamp integration', () => {
     expect(timestamp).toHaveAttribute('id', 'notetimestamp_1');
     expect(timestamp.tagName).toBe('TIME');
     expect(timestamp).toHaveAttribute('datetime', '2026-04-01T12:00:00.000Z');
+    expect(timestamp).toHaveTextContent('Created: Apr 1, 2026, 8:00 AM');
+    expect(timestamp).not.toHaveTextContent('UTC');
   });
 
   test('list shows last edited timestamp when updatedAt is present', async () => {
@@ -82,6 +87,8 @@ describe('note timestamp integration', () => {
     const timestamp = screen.getByText(/Last edited:/);
     expect(timestamp).toHaveAttribute('id', 'notetimestamp_1');
     expect(timestamp).toHaveAttribute('datetime', '2026-04-29T15:30:00.000Z');
+    expect(timestamp).toHaveTextContent('Last edited: Apr 29, 2026, 11:30 AM');
+    expect(timestamp).not.toHaveTextContent('UTC');
   });
 
   test('add note posts createdAt and navigates back to the list', async () => {

--- a/src/components/NoteTimestamp.integration.test.js
+++ b/src/components/NoteTimestamp.integration.test.js
@@ -30,17 +30,26 @@ import EditNote from './EditNote';
 import ListNotes from './ListNotes';
 
 const mockedAxios = axios;
-const originalTimeZone = process.env.TZ;
+const originalDateTimeFormat = Intl.DateTimeFormat;
 
 describe('note timestamp integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.TZ = 'America/New_York';
+    Intl.DateTimeFormat = jest.fn((locale, options) => {
+      const formatter = new originalDateTimeFormat(locale, {
+        ...options,
+        timeZone: 'America/New_York',
+      });
+
+      return {
+        format: formatter.format.bind(formatter),
+      };
+    });
   });
 
   afterEach(() => {
     jest.useRealTimers();
-    process.env.TZ = originalTimeZone;
+    Intl.DateTimeFormat = originalDateTimeFormat;
   });
 
   test('list shows created timestamp for seeded notes', async () => {

--- a/src/utils/formatNoteTimestamp.js
+++ b/src/utils/formatNoteTimestamp.js
@@ -1,12 +1,12 @@
-const timestampFormatter = new Intl.DateTimeFormat('en-US', {
-  year: 'numeric',
-  month: 'short',
-  day: 'numeric',
-  hour: 'numeric',
-  minute: '2-digit',
-  timeZone: 'UTC',
-  timeZoneName: 'short',
-});
+function createTimestampFormatter() {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
 
 export function formatNoteTimestamp(isoString) {
   const date = new Date(isoString);
@@ -15,7 +15,7 @@ export function formatNoteTimestamp(isoString) {
     return null;
   }
 
-  return timestampFormatter.format(date);
+  return createTimestampFormatter().format(date);
 }
 
 export function getNoteTimestampDetails(note) {

--- a/src/utils/formatNoteTimestamp.test.js
+++ b/src/utils/formatNoteTimestamp.test.js
@@ -3,20 +3,27 @@ import {
   getNoteTimestampDetails,
 } from './formatNoteTimestamp';
 
-function runInTimezone(timeZone, callback) {
-  const originalTimeZone = process.env.TZ;
-  process.env.TZ = timeZone;
+function runWithPinnedTimezone(timeZone, callback) {
+  const realDateTimeFormat = Intl.DateTimeFormat;
+  const dateTimeFormatSpy = jest
+    .spyOn(Intl, 'DateTimeFormat')
+    .mockImplementation((locale, options = {}) => {
+      return new realDateTimeFormat(locale, {
+        ...options,
+        timeZone,
+      });
+    });
 
   try {
     callback();
   } finally {
-    process.env.TZ = originalTimeZone;
+    dateTimeFormatSpy.mockRestore();
   }
 }
 
 describe('formatNoteTimestamp', () => {
   test('formats a valid ISO timestamp into readable absolute text', () => {
-    runInTimezone('America/New_York', () => {
+    runWithPinnedTimezone('America/New_York', () => {
       expect(formatNoteTimestamp('2026-04-01T12:00:00.000Z')).toBe(
         'Apr 1, 2026, 8:00 AM'
       );
@@ -30,7 +37,7 @@ describe('formatNoteTimestamp', () => {
 
 describe('getNoteTimestampDetails', () => {
   test('uses createdAt when a note has never been edited', () => {
-    runInTimezone('America/New_York', () => {
+    runWithPinnedTimezone('America/New_York', () => {
       expect(
         getNoteTimestampDetails({
           createdAt: '2026-04-01T12:00:00.000Z',
@@ -45,7 +52,7 @@ describe('getNoteTimestampDetails', () => {
   });
 
   test('prefers updatedAt and last edited label when present', () => {
-    runInTimezone('America/New_York', () => {
+    runWithPinnedTimezone('America/New_York', () => {
       expect(
         getNoteTimestampDetails({
           createdAt: '2026-04-01T12:00:00.000Z',

--- a/src/utils/formatNoteTimestamp.test.js
+++ b/src/utils/formatNoteTimestamp.test.js
@@ -3,11 +3,24 @@ import {
   getNoteTimestampDetails,
 } from './formatNoteTimestamp';
 
+function runInTimezone(timeZone, callback) {
+  const originalTimeZone = process.env.TZ;
+  process.env.TZ = timeZone;
+
+  try {
+    callback();
+  } finally {
+    process.env.TZ = originalTimeZone;
+  }
+}
+
 describe('formatNoteTimestamp', () => {
   test('formats a valid ISO timestamp into readable absolute text', () => {
-    expect(formatNoteTimestamp('2026-04-01T12:00:00.000Z')).toBe(
-      'Apr 1, 2026, 12:00 PM UTC'
-    );
+    runInTimezone('America/New_York', () => {
+      expect(formatNoteTimestamp('2026-04-01T12:00:00.000Z')).toBe(
+        'Apr 1, 2026, 8:00 AM'
+      );
+    });
   });
 
   test('returns null for an invalid timestamp', () => {
@@ -17,29 +30,33 @@ describe('formatNoteTimestamp', () => {
 
 describe('getNoteTimestampDetails', () => {
   test('uses createdAt when a note has never been edited', () => {
-    expect(
-      getNoteTimestampDetails({
-        createdAt: '2026-04-01T12:00:00.000Z',
-      })
-    ).toEqual({
-      label: 'Created',
-      isoString: '2026-04-01T12:00:00.000Z',
-      displayText: 'Apr 1, 2026, 12:00 PM UTC',
-      text: 'Created: Apr 1, 2026, 12:00 PM UTC',
+    runInTimezone('America/New_York', () => {
+      expect(
+        getNoteTimestampDetails({
+          createdAt: '2026-04-01T12:00:00.000Z',
+        })
+      ).toEqual({
+        label: 'Created',
+        isoString: '2026-04-01T12:00:00.000Z',
+        displayText: 'Apr 1, 2026, 8:00 AM',
+        text: 'Created: Apr 1, 2026, 8:00 AM',
+      });
     });
   });
 
   test('prefers updatedAt and last edited label when present', () => {
-    expect(
-      getNoteTimestampDetails({
-        createdAt: '2026-04-01T12:00:00.000Z',
-        updatedAt: '2026-04-29T14:00:00.000Z',
-      })
-    ).toEqual({
-      label: 'Last edited',
-      isoString: '2026-04-29T14:00:00.000Z',
-      displayText: 'Apr 29, 2026, 2:00 PM UTC',
-      text: 'Last edited: Apr 29, 2026, 2:00 PM UTC',
+    runInTimezone('America/New_York', () => {
+      expect(
+        getNoteTimestampDetails({
+          createdAt: '2026-04-01T12:00:00.000Z',
+          updatedAt: '2026-04-29T14:00:00.000Z',
+        })
+      ).toEqual({
+        label: 'Last edited',
+        isoString: '2026-04-29T14:00:00.000Z',
+        displayText: 'Apr 29, 2026, 10:00 AM',
+        text: 'Last edited: Apr 29, 2026, 10:00 AM',
+      });
     });
   });
 

--- a/tests/NotesTests.spec.ts
+++ b/tests/NotesTests.spec.ts
@@ -6,6 +6,8 @@ import { EditNotePage } from "./pages/EditNotePage";
 
 test.describe.configure({ mode: "serial" });
 
+const TIMESTAMP_TIMEZONE_ID = "America/New_York";
+
 test.afterAll(async () => {
     await reSeedData();
 });
@@ -106,4 +108,17 @@ test("verify seeded note shows created timestamp", async ({ page }) => {
     const homepage = new HomePage(page);
     await expect(page.locator("#notetitle_1 > div")).toHaveText("Test note");
     await homepage.expectTimestampById("1", /^Created: .+/);
+});
+
+test.describe("timestamp display uses viewer local time", () => {
+    test.use({ timezoneId: TIMESTAMP_TIMEZONE_ID });
+
+    test("verify seeded note shows local created timestamp without UTC suffix", async ({ page }) => {
+        const homepage = new HomePage(page);
+
+        await expect(page.locator("#notetitle_1 > div")).toHaveText("Test note");
+        await homepage.expectTimestampById("1", "Created: Apr 1, 2026, 8:00 AM");
+        await expect(homepage.getNoteTimestamp("1")).not.toContainText("UTC");
+        await expect(homepage.getNoteTimestamp("1")).toHaveAttribute("datetime", "2026-04-01T12:00:00.000Z");
+    });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement `feature/local-time-timestamp-display/tech-spec.md` by removing forced UTC formatting from the shared note timestamp formatter so note timestamps render in the viewer's local time
- update timestamp-focused React tests to pin a deterministic non-UTC timezone through `Intl.DateTimeFormat` mocking while preserving `Created` / `Last edited`, stable ids, and `<time dateTime>` semantics
- add a Playwright timezone-pinned assertion proving the seeded note renders `America/New_York` local wall-clock time without a `UTC` suffix

## Tech Spec traceability
- **Architecture / High-level design**: keep the change inside `src/utils/formatNoteTimestamp.js`
- **UI / client**: preserve existing labels, selectors, and `<time>` semantics while removing UTC-specific visible output
- **Testing approach**: make unit, integration, and E2E timestamp assertions deterministic in a controlled non-UTC timezone

## Validation
- `npm run build`
- `CI=true npx react-scripts test --watchAll=false --runTestsByPath src/utils/formatNoteTimestamp.test.js src/components/NoteTimestamp.integration.test.js`
- `npx playwright test`

Related to #12
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-674e871a-db10-4a36-990a-b0f547fb1c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-674e871a-db10-4a36-990a-b0f547fb1c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

