### PR TITLE
feat: bold note titles in the main list view

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -154,6 +154,10 @@ table {
   width: 100%;
 }
 
+.note-list-title {
+  font-weight: 700;
+}
+
 #notes tr:nth-child(even){background-color: #f2f2f2;}
 
 @keyframes App-logo-spin {

--- a/src/components/ListNotes.js
+++ b/src/components/ListNotes.js
@@ -38,7 +38,7 @@ const ListNotes = () => {
 						return (
 							<tr key={post.id}>
 								<td id={"notetitle_"+post.id}>
-									<div>{post.title}</div>
+									<div className="note-list-title">{post.title}</div>
 									{timestampDetails ? (
 										<time
 											id={"notetimestamp_" + post.id}

--- a/src/components/NoteTimestamp.integration.test.js
+++ b/src/components/NoteTimestamp.integration.test.js
@@ -100,6 +100,37 @@ describe('note timestamp integration', () => {
     expect(timestamp).not.toHaveTextContent('UTC');
   });
 
+  test('list keeps title wrapper and action links while styling only the title', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: '42',
+          title: 'Bold note title',
+          description: 'Existing note',
+          createdAt: '2026-04-01T12:00:00.000Z',
+        },
+      ],
+    });
+
+    render(<ListNotes />);
+
+    const title = await screen.findByText('Bold note title');
+    expect(title.tagName).toBe('DIV');
+    expect(title).toHaveClass('note-list-title');
+
+    const titleCell = title.closest('td');
+    expect(titleCell).toHaveAttribute('id', 'notetitle_42');
+
+    const timestamp = screen.getByText(/Created:/);
+    expect(timestamp.tagName).toBe('TIME');
+    expect(timestamp).toHaveAttribute('id', 'notetimestamp_42');
+    expect(timestamp).not.toHaveClass('note-list-title');
+
+    expect(screen.getByRole('link', { name: 'View' })).toHaveAttribute('id', 'view_42');
+    expect(screen.getByRole('link', { name: 'Edit' })).toHaveAttribute('id', 'edit_42');
+    expect(screen.getByText('Delete')).toHaveAttribute('id', 'delete_42');
+  });
+
   test('add note posts createdAt and navigates back to the list', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2026-04-29T14:00:00.000Z'));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement the `feature/bold-note-list-title/tech-spec.md` UI/client contract by adding a dedicated `note-list-title` hook to the existing direct child title wrapper in `ListNotes`
- add scoped CSS that bolds only the note title text and leaves timestamps visually separate
- add focused list integration coverage proving the title hook, timestamp markup, and existing action ids remain intact

## Tech Spec Traceability
- **Architecture / UI / client:** preserve `#notetitle_${id} > div` while applying explicit bold styling to the title wrapper only
- **APIs & contracts:** keep row ids, timestamp ids, and action ids unchanged
- **Testing approach:** add targeted component coverage and run the existing Playwright suite for list/create/edit regression coverage

## Verification
- `CI=true npx react-scripts test --runInBand --watch=false --runTestsByPath src/components/NoteTimestamp.integration.test.js src/components/NoteEditorFields.test.js src/utils/formatNoteTimestamp.test.js`
- `npm run build`
- `npx playwright test`

Closes #17
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e2ae91d-49ec-497b-8359-fdd4a23e00a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e2ae91d-49ec-497b-8359-fdd4a23e00a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

